### PR TITLE
カラーパレットの変更と調整

### DIFF
--- a/tokens/reference/color.default.json
+++ b/tokens/reference/color.default.json
@@ -43,31 +43,31 @@
               "$type": "color"
             },
             "300": {
-              "$value": "#CECDC9",
+              "$value": "#D1D0CD",
               "$type": "color"
             },
             "400": {
-              "$value": "#B6B5B1",
+              "$value": "#B1B0AE",
               "$type": "color"
             },
             "500": {
-              "$value": "#999894",
+              "$value": "#8C8B87",
               "$type": "color"
             },
             "600": {
-              "$value": "#737370",
+              "$value": "#6F6F6F",
               "$type": "color"
             },
             "700": {
-              "$value": "#525250",
+              "$value": "#575757",
               "$type": "color"
             },
             "800": {
-              "$value": "#3F3F3D",
+              "$value": "#424242",
               "$type": "color"
             },
             "900": {
-              "$value": "#373736",
+              "$value": "#31312F",
               "$type": "color"
             },
             "1000": {
@@ -77,19 +77,19 @@
           },
           "red": {
             "100": {
-              "$value": "#FEF0EF",
+              "$value": "#FCEBEA",
               "$type": "color"
             },
             "200": {
-              "$value": "#FEDBD8",
+              "$value": "#FFDCDA",
               "$type": "color"
             },
             "300": {
-              "$value": "#FFC4BF",
+              "$value": "#FFC0BB",
               "$type": "color"
             },
             "400": {
-              "$value": "#FF9D96",
+              "$value": "#FF8F8F",
               "$type": "color"
             },
             "500": {
@@ -97,7 +97,7 @@
               "$type": "color"
             },
             "600": {
-              "$value": "#D60037",
+              "$value": "#D00138",
               "$type": "color"
             },
             "700": {
@@ -109,45 +109,45 @@
               "$type": "color"
             },
             "900": {
-              "$value": "#650417",
+              "$value": "#600114",
               "$type": "color"
             },
             "1000": {
-              "$value": "#49060E",
+              "$value": "#400109",
               "$type": "color"
             }
           },
           "chestnut": {
             "100": {
-              "$value": "#FCF0EA",
+              "$value": "#FAECE6",
               "$type": "color"
             },
             "200": {
-              "$value": "#FADECF",
+              "$value": "#FDDDCE",
               "$type": "color"
             },
             "300": {
-              "$value": "#F9CFB9",
+              "$value": "#FCC4AB",
               "$type": "color"
             },
             "400": {
-              "$value": "#F6A87B",
+              "$value": "#F49972",
               "$type": "color"
             },
             "500": {
-              "$value": "#E5712D",
+              "$value": "#DC6733",
               "$type": "color"
             },
             "600": {
-              "$value": "#B2521E",
+              "$value": "#B54E1B",
               "$type": "color"
             },
             "700": {
-              "$value": "#803510",
+              "$value": "#8F3D15",
               "$type": "color"
             },
             "800": {
-              "$value": "#71330F",
+              "$value": "#702D0D",
               "$type": "color"
             },
             "900": {
@@ -165,35 +165,35 @@
               "$type": "color"
             },
             "200": {
-              "$value": "#FAEAD7",
+              "$value": "#F6E0C6",
               "$type": "color"
             },
             "300": {
-              "$value": "#F5D5AE",
+              "$value": "#F0CC9E",
               "$type": "color"
             },
             "400": {
-              "$value": "#E9BD7D",
+              "$value": "#DEB074",
               "$type": "color"
             },
             "500": {
-              "$value": "#C09858",
+              "$value": "#AE8144",
               "$type": "color"
             },
             "600": {
-              "$value": "#8F6E3A",
+              "$value": "#8D6735",
               "$type": "color"
             },
             "700": {
-              "$value": "#684C26",
+              "$value": "#70522A",
               "$type": "color"
             },
             "800": {
-              "$value": "#5A4321",
+              "$value": "#573F1D",
               "$type": "color"
             },
             "900": {
-              "$value": "#46341A",
+              "$value": "#3E2D17",
               "$type": "color"
             },
             "1000": {
@@ -203,39 +203,39 @@
           },
           "yellow": {
             "100": {
-              "$value": "#FFF4D6",
+              "$value": "#FAF4E3",
               "$type": "color"
             },
             "200": {
-              "$value": "#FFECA6",
+              "$value": "#FCE998",
               "$type": "color"
             },
             "300": {
-              "$value": "#FFE162",
+              "$value": "#EDD857",
               "$type": "color"
             },
             "400": {
-              "$value": "#E9CF00",
+              "$value": "#DEC400",
               "$type": "color"
             },
             "500": {
-              "$value": "#B9A000",
+              "$value": "#A78E00",
               "$type": "color"
             },
             "600": {
-              "$value": "#8E7A00",
+              "$value": "#816E00",
               "$type": "color"
             },
             "700": {
-              "$value": "#5F5100",
+              "$value": "#645600",
               "$type": "color"
             },
             "800": {
-              "$value": "#534700",
+              "$value": "#514400",
               "$type": "color"
             },
             "900": {
-              "$value": "#413700",
+              "$value": "#3A3000",
               "$type": "color"
             },
             "1000": {
@@ -245,39 +245,39 @@
           },
           "green": {
             "100": {
-              "$value": "#E6FBF3",
+              "$value": "#DBF5EA",
               "$type": "color"
             },
             "200": {
-              "$value": "#CFF6E8",
+              "$value": "#BCEEDD",
               "$type": "color"
             },
             "300": {
-              "$value": "#B7F2DD",
+              "$value": "#90E4C7",
               "$type": "color"
             },
             "400": {
-              "$value": "#8BE9C7",
+              "$value": "#46D2A2",
               "$type": "color"
             },
             "500": {
-              "$value": "#48B897",
+              "$value": "#2EAB80",
               "$type": "color"
             },
             "600": {
-              "$value": "#318366",
+              "$value": "#2C7C60",
               "$type": "color"
             },
             "700": {
-              "$value": "#266751",
+              "$value": "#146348",
               "$type": "color"
             },
             "800": {
-              "$value": "#1C503E",
+              "$value": "#174A38",
               "$type": "color"
             },
             "900": {
-              "$value": "#143E30",
+              "$value": "#12372B",
               "$type": "color"
             },
             "1000": {
@@ -287,39 +287,39 @@
           },
           "skyBlue": {
             "100": {
-              "$value": "#E5FBFF",
+              "$value": "#D9F6FC",
               "$type": "color"
             },
             "200": {
-              "$value": "#D1F5FA",
+              "$value": "#C2EAEF",
               "$type": "color"
             },
             "300": {
-              "$value": "#B4EFF7",
+              "$value": "#8DDDE3",
               "$type": "color"
             },
             "400": {
-              "$value": "#7DDDE7",
+              "$value": "#4ACBD4",
               "$type": "color"
             },
             "500": {
-              "$value": "#00B3C2",
+              "$value": "#00A0AC",
               "$type": "color"
             },
             "600": {
-              "$value": "#008290",
+              "$value": "#007882",
               "$type": "color"
             },
             "700": {
-              "$value": "#015C63",
+              "$value": "#006066",
               "$type": "color"
             },
             "800": {
-              "$value": "#01474C",
+              "$value": "#004A4F",
               "$type": "color"
             },
             "900": {
-              "$value": "#033E43",
+              "$value": "#02373C",
               "$type": "color"
             },
             "1000": {
@@ -329,31 +329,31 @@
           },
           "blue": {
             "100": {
-              "$value": "#F0F5FF",
+              "$value": "#EFF2FC",
               "$type": "color"
             },
             "200": {
-              "$value": "#DCE6FF",
+              "$value": "#DDE3FF",
               "$type": "color"
             },
             "300": {
-              "$value": "#C7D6FF",
+              "$value": "#C0CFFD",
               "$type": "color"
             },
             "400": {
-              "$value": "#9EBBFF",
+              "$value": "#8FAEFE",
               "$type": "color"
             },
             "500": {
-              "$value": "#5399FF",
+              "$value": "#3B86F9",
               "$type": "color"
             },
             "600": {
-              "$value": "#0A69CF",
+              "$value": "#056AD8",
               "$type": "color"
             },
             "700": {
-              "$value": "#0650A0",
+              "$value": "#0353AA",
               "$type": "color"
             },
             "800": {
@@ -371,35 +371,35 @@
           },
           "purple": {
             "100": {
-              "$value": "#F5F0FA",
+              "$value": "#F4ECF6",
               "$type": "color"
             },
             "200": {
-              "$value": "#EDDEF6",
+              "$value": "#EEDEF2",
               "$type": "color"
             },
             "300": {
-              "$value": "#E1C5ED",
+              "$value": "#E1C7E7",
               "$type": "color"
             },
             "400": {
-              "$value": "#D4ACE4",
+              "$value": "#CC9FD9",
               "$type": "color"
             },
             "500": {
-              "$value": "#B76FCD",
+              "$value": "#B36CCD",
               "$type": "color"
             },
             "600": {
-              "$value": "#9E58B3",
+              "$value": "#9751B0",
               "$type": "color"
             },
             "700": {
-              "$value": "#733B85",
+              "$value": "#7C3694",
               "$type": "color"
             },
             "800": {
-              "$value": "#592D68",
+              "$value": "#5F2B70",
               "$type": "color"
             },
             "900": {
@@ -413,43 +413,43 @@
           },
           "pink": {
             "100": {
-              "$value": "#FFF0F5",
+              "$value": "#FFF4F8",
               "$type": "color"
             },
             "200": {
-              "$value": "#FEDDE9",
+              "$value": "#F9DCE5",
               "$type": "color"
             },
             "300": {
-              "$value": "#FDCADB",
+              "$value": "#F3C4D3",
               "$type": "color"
             },
             "400": {
-              "$value": "#FAA1C3",
+              "$value": "#F691B6",
               "$type": "color"
             },
             "500": {
-              "$value": "#F55D9B",
+              "$value": "#E2568F",
               "$type": "color"
             },
             "600": {
-              "$value": "#C63B74",
+              "$value": "#B9346C",
               "$type": "color"
             },
             "700": {
-              "$value": "#9E2A5A",
+              "$value": "#9B2657",
               "$type": "color"
             },
             "800": {
-              "$value": "#7A2047",
+              "$value": "#761A42",
               "$type": "color"
             },
             "900": {
-              "$value": "#601939",
+              "$value": "#591734",
               "$type": "color"
             },
             "1000": {
-              "$value": "#401026",
+              "$value": "#3E0F24",
               "$type": "color"
             }
           }

--- a/tokens/reference/color.default.json
+++ b/tokens/reference/color.default.json
@@ -35,27 +35,27 @@
           },
           "gray": {
             "100": {
-              "$value": "#EFEEEB",
+              "$value": "#F0F0F0",
               "$type": "color"
             },
             "200": {
-              "$value": "#D9D8D3",
+              "$value": "#E4E4E3",
               "$type": "color"
             },
             "300": {
-              "$value": "#C8C7C2",
+              "$value": "#CECDC9",
               "$type": "color"
             },
             "400": {
-              "$value": "#AFAEAA",
+              "$value": "#B6B5B1",
               "$type": "color"
             },
             "500": {
-              "$value": "#8C8B87",
+              "$value": "#999894",
               "$type": "color"
             },
             "600": {
-              "$value": "#696966",
+              "$value": "#737370",
               "$type": "color"
             },
             "700": {
@@ -67,7 +67,7 @@
               "$type": "color"
             },
             "900": {
-              "$value": "#31312F",
+              "$value": "#373736",
               "$type": "color"
             },
             "1000": {
@@ -77,27 +77,27 @@
           },
           "red": {
             "100": {
-              "$value": "#FCEBEA",
+              "$value": "#FEF0EF",
               "$type": "color"
             },
             "200": {
-              "$value": "#FCD6D3",
+              "$value": "#FEDBD8",
               "$type": "color"
             },
             "300": {
-              "$value": "#FDB9B4",
+              "$value": "#FFC4BF",
               "$type": "color"
             },
             "400": {
-              "$value": "#FF8F8F",
+              "$value": "#FF9D96",
               "$type": "color"
             },
             "500": {
-              "$value": "#F84258",
+              "$value": "#F64157",
               "$type": "color"
             },
             "600": {
-              "$value": "#CE0037",
+              "$value": "#D60037",
               "$type": "color"
             },
             "700": {
@@ -119,27 +119,27 @@
           },
           "chestnut": {
             "100": {
-              "$value": "#FAECE6",
+              "$value": "#FCF0EA",
               "$type": "color"
             },
             "200": {
-              "$value": "#F7D8C9",
+              "$value": "#FADECF",
               "$type": "color"
             },
             "300": {
-              "$value": "#F7C6B0",
+              "$value": "#F9CFB9",
               "$type": "color"
             },
             "400": {
-              "$value": "#F49567",
+              "$value": "#F6A87B",
               "$type": "color"
             },
             "500": {
-              "$value": "#E26324",
+              "$value": "#E5712D",
               "$type": "color"
             },
             "600": {
-              "$value": "#AB4919",
+              "$value": "#B2521E",
               "$type": "color"
             },
             "700": {
@@ -147,7 +147,7 @@
               "$type": "color"
             },
             "800": {
-              "$value": "#692C0D",
+              "$value": "#71330F",
               "$type": "color"
             },
             "900": {
@@ -161,27 +161,27 @@
           },
           "beige": {
             "100": {
-              "$value": "#F7EDE2",
+              "$value": "#FDF5EC",
               "$type": "color"
             },
             "200": {
-              "$value": "#F2DBC0",
+              "$value": "#FAEAD7",
               "$type": "color"
             },
             "300": {
-              "$value": "#EDC18A",
+              "$value": "#F5D5AE",
               "$type": "color"
             },
             "400": {
-              "$value": "#DAA358",
+              "$value": "#E9BD7D",
               "$type": "color"
             },
             "500": {
-              "$value": "#AF8245",
+              "$value": "#C09858",
               "$type": "color"
             },
             "600": {
-              "$value": "#846132",
+              "$value": "#8F6E3A",
               "$type": "color"
             },
             "700": {
@@ -189,11 +189,11 @@
               "$type": "color"
             },
             "800": {
-              "$value": "#503A1C",
+              "$value": "#5A4321",
               "$type": "color"
             },
             "900": {
-              "$value": "#3E2D17",
+              "$value": "#46341A",
               "$type": "color"
             },
             "1000": {
@@ -203,27 +203,27 @@
           },
           "yellow": {
             "100": {
-              "$value": "#FEEDBE",
+              "$value": "#FFF4D6",
               "$type": "color"
             },
             "200": {
-              "$value": "#FFE885",
+              "$value": "#FFECA6",
               "$type": "color"
             },
             "300": {
-              "$value": "#EFD616",
+              "$value": "#FFE162",
               "$type": "color"
             },
             "400": {
-              "$value": "#D8BF00",
+              "$value": "#E9CF00",
               "$type": "color"
             },
             "500": {
-              "$value": "#AC9301",
+              "$value": "#B9A000",
               "$type": "color"
             },
             "600": {
-              "$value": "#857100",
+              "$value": "#8E7A00",
               "$type": "color"
             },
             "700": {
@@ -231,11 +231,11 @@
               "$type": "color"
             },
             "800": {
-              "$value": "#4A3E00",
+              "$value": "#534700",
               "$type": "color"
             },
             "900": {
-              "$value": "#3A3000",
+              "$value": "#413700",
               "$type": "color"
             },
             "1000": {
@@ -245,27 +245,27 @@
           },
           "green": {
             "100": {
-              "$value": "#CAF9E6",
+              "$value": "#E6FBF3",
               "$type": "color"
             },
             "200": {
-              "$value": "#B1EAD7",
+              "$value": "#CFF6E8",
               "$type": "color"
             },
             "300": {
-              "$value": "#98E1C8",
+              "$value": "#B7F2DD",
               "$type": "color"
             },
             "400": {
-              "$value": "#6ED0AE",
+              "$value": "#8BE9C7",
               "$type": "color"
             },
             "500": {
-              "$value": "#40A683",
+              "$value": "#48B897",
               "$type": "color"
             },
             "600": {
-              "$value": "#2C755C",
+              "$value": "#318366",
               "$type": "color"
             },
             "700": {
@@ -273,11 +273,11 @@
               "$type": "color"
             },
             "800": {
-              "$value": "#184737",
+              "$value": "#1C503E",
               "$type": "color"
             },
             "900": {
-              "$value": "#12372B",
+              "$value": "#143E30",
               "$type": "color"
             },
             "1000": {
@@ -287,27 +287,27 @@
           },
           "skyBlue": {
             "100": {
-              "$value": "#D9F6FC",
+              "$value": "#E5FBFF",
               "$type": "color"
             },
             "200": {
-              "$value": "#C3EFF4",
+              "$value": "#D1F5FA",
               "$type": "color"
             },
             "300": {
-              "$value": "#9CE6EC",
+              "$value": "#B4EFF7",
               "$type": "color"
             },
             "400": {
-              "$value": "#64CCD3",
+              "$value": "#7DDDE7",
               "$type": "color"
             },
             "500": {
-              "$value": "#00A3AF",
+              "$value": "#00B3C2",
               "$type": "color"
             },
             "600": {
-              "$value": "#00757E",
+              "$value": "#008290",
               "$type": "color"
             },
             "700": {
@@ -319,7 +319,7 @@
               "$type": "color"
             },
             "900": {
-              "$value": "#02373C",
+              "$value": "#033E43",
               "$type": "color"
             },
             "1000": {
@@ -329,23 +329,23 @@
           },
           "blue": {
             "100": {
-              "$value": "#EFF2FC",
+              "$value": "#F0F5FF",
               "$type": "color"
             },
             "200": {
-              "$value": "#D7DEFB",
+              "$value": "#DCE6FF",
               "$type": "color"
             },
             "300": {
-              "$value": "#BFCEFC",
+              "$value": "#C7D6FF",
               "$type": "color"
             },
             "400": {
-              "$value": "#8FAEFE",
+              "$value": "#9EBBFF",
               "$type": "color"
             },
             "500": {
-              "$value": "#428CFE",
+              "$value": "#5399FF",
               "$type": "color"
             },
             "600": {
@@ -371,27 +371,27 @@
           },
           "purple": {
             "100": {
-              "$value": "#F4ECF6",
+              "$value": "#F5F0FA",
               "$type": "color"
             },
             "200": {
-              "$value": "#EADAEE",
+              "$value": "#EDDEF6",
               "$type": "color"
             },
             "300": {
-              "$value": "#DCBDE4",
+              "$value": "#E1C5ED",
               "$type": "color"
             },
             "400": {
-              "$value": "#CC9FD9",
+              "$value": "#D4ACE4",
               "$type": "color"
             },
             "500": {
-              "$value": "#AA61C2",
+              "$value": "#B76FCD",
               "$type": "color"
             },
             "600": {
-              "$value": "#914DA9",
+              "$value": "#9E58B3",
               "$type": "color"
             },
             "700": {
@@ -413,39 +413,39 @@
           },
           "pink": {
             "100": {
-              "$value": "#F9EBF0",
+              "$value": "#FFF0F5",
               "$type": "color"
             },
             "200": {
-              "$value": "#F6D7E0",
+              "$value": "#FEDDE9",
               "$type": "color"
             },
             "300": {
-              "$value": "#F5C1D1",
+              "$value": "#FDCADB",
               "$type": "color"
             },
             "400": {
-              "$value": "#F190B4",
+              "$value": "#FAA1C3",
               "$type": "color"
             },
             "500": {
-              "$value": "#EB4F8E",
+              "$value": "#F55D9B",
               "$type": "color"
             },
             "600": {
-              "$value": "#B9336B",
+              "$value": "#C63B74",
               "$type": "color"
             },
             "700": {
-              "$value": "#932653",
+              "$value": "#9E2A5A",
               "$type": "color"
             },
             "800": {
-              "$value": "#711D41",
+              "$value": "#7A2047",
               "$type": "color"
             },
             "900": {
-              "$value": "#591734",
+              "$value": "#601939",
               "$type": "color"
             },
             "1000": {

--- a/tokens/system/color.asagi.json
+++ b/tokens/system/color.asagi.json
@@ -101,7 +101,7 @@
           },
           "tertiary": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.gray.200}",
+            "$value": "{sd.reference.color.scale.gray.100}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -125,7 +125,7 @@
           },
           "tertiaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.gray.200}",
+            "$value": "{sd.reference.color.scale.gray.100}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {

--- a/tokens/system/color.asagi.json
+++ b/tokens/system/color.asagi.json
@@ -5,7 +5,7 @@
         "impression": {
           "primary": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.skyBlue.600}",
+            "$value": "{sd.reference.color.scale.skyBlue.700}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -29,7 +29,7 @@
           },
           "primaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.skyBlue.600}",
+            "$value": "{sd.reference.color.scale.skyBlue.700}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -53,7 +53,7 @@
           },
           "secondary": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.green.200}",
+            "$value": "{sd.reference.color.scale.green.300}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -77,7 +77,7 @@
           },
           "secondaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.green.200}",
+            "$value": "{sd.reference.color.scale.green.300}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -101,7 +101,7 @@
           },
           "tertiary": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.gray.100}",
+            "$value": "{sd.reference.color.scale.gray.200}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -125,7 +125,7 @@
           },
           "tertiaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.gray.100}",
+            "$value": "{sd.reference.color.scale.gray.200}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -524,7 +524,7 @@
           },
           "selectedSurface": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.green.200}",
+            "$value": "{sd.reference.color.scale.green.300}",
             "$description": "surface色をselected状態にするときに使用 (ListItemなど)",
             "$extensions": {
               "com.figma": {

--- a/tokens/system/color.tsutsuji.json
+++ b/tokens/system/color.tsutsuji.json
@@ -5,7 +5,7 @@
         "impression": {
           "primary": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.600}",
+            "$value": "{sd.reference.color.scale.pink.700}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -29,7 +29,7 @@
           },
           "primaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.300}",
+            "$value": "{sd.reference.color.scale.pink.400}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -53,7 +53,7 @@
           },
           "secondary": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.200}",
+            "$value": "{sd.reference.color.scale.pink.300}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -77,7 +77,7 @@
           },
           "secondaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.200}",
+            "$value": "{sd.reference.color.scale.pink.300}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -245,7 +245,7 @@
           },
           "negativeContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.red.200}",
+            "$value": "{sd.reference.color.scale.red.300}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -524,7 +524,7 @@
           },
           "selectedSurface": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.100}",
+            "$value": "{sd.reference.color.scale.pink.200}",
             "$description": "surface色をselected状態にするときに使用 (ListItemなど)",
             "$extensions": {
               "com.figma": {

--- a/tokens/system/color.tsutsuji.json
+++ b/tokens/system/color.tsutsuji.json
@@ -29,7 +29,7 @@
           },
           "primaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.400}",
+            "$value": "{sd.reference.color.scale.pink.200}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -101,7 +101,7 @@
           },
           "tertiary": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.1000}",
+            "$value": "{sd.reference.color.scale.pink.900}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -125,7 +125,7 @@
           },
           "tertiaryContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.1000}",
+            "$value": "{sd.reference.color.scale.pink.900}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {
@@ -524,7 +524,7 @@
           },
           "selectedSurface": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.pink.200}",
+            "$value": "{sd.reference.color.scale.pink.300}",
             "$description": "surface色をselected状態にするときに使用 (ListItemなど)",
             "$extensions": {
               "com.figma": {

--- a/tokens/system/color.tsutsuji.json
+++ b/tokens/system/color.tsutsuji.json
@@ -245,7 +245,7 @@
           },
           "negativeContainer": {
             "$type": "color",
-            "$value": "{sd.reference.color.scale.red.300}",
+            "$value": "{sd.reference.color.scale.red.200}",
             "$extensions": {
               "com.figma": {
                 "codeSyntax": {


### PR DESCRIPTION
## 概要

カラーパレットのAPCA/WCAG準拠を行うためのカラー調整を行うため、デザイントークンの修正を行いました。

### Reference Color

下記のカラーパレットを変更しています：
`gray, red, chestnut, beige, yellow, green, skyBlue, blue, purple, pink`

### System Color
Theme: Asagi, Tsutsujiにおける下記カラー参照を変更しています：
`primary, primaryContainer, secondary, secondaryContainer, tertiary, tertiaryContainer, selectedSurface`

## 手順

- Figma のBranch Reviewを確認
- 表示されているVariableのtableをHTML Elementごと取得(F12)
- Claude Codeにそのコードをそのまま渡し、解読してもらい変更